### PR TITLE
Remove trapi.CURIE from validation

### DIFF
--- a/api_watchdog/validate.py
+++ b/api_watchdog/validate.py
@@ -53,7 +53,6 @@ class ValidationType(Enum):
     TrapiAttribute          = "trapi.attribute"
     TrapiBiolinkEntity      = "trapi.biolink_entity"
     TrapiBiolinkPredicate   = "trapi.biolink_predicate"
-    TrapiCurie              = "trapi.curie"
     TrapiLogEntry           = "trapi.log_entry"
     TrapiLogLevel           = "trapi.log_level"
     TrapiMetaEdge           = "trapi.meta_edge"
@@ -87,7 +86,6 @@ validation_registry = {
     ValidationType.TrapiAttribute         : trapi.Attribute         ,
     ValidationType.TrapiBiolinkEntity     : trapi.BiolinkEntity     ,
     ValidationType.TrapiBiolinkPredicate  : trapi.BiolinkPredicate  ,
-    ValidationType.TrapiCurie             : trapi.CURIE             ,
     ValidationType.TrapiLogEntry          : trapi.LogEntry          ,
     ValidationType.TrapiLogLevel          : trapi.LogLevel          ,
     ValidationType.TrapiMetaEdge          : trapi.MetaEdge          ,


### PR DESCRIPTION
Remove trapi.CURIE as a validation type. Due to recent changes in reasoner-pydantic this type is no longer possible to use in the same manner.

All previous uses of trapi.CURIE for type validation should just use string.